### PR TITLE
feat: Add status LED support to signal startup sequence completion

### DIFF
--- a/shared/core/hal.h
+++ b/shared/core/hal.h
@@ -111,6 +111,37 @@ uint32_t hal_random32(void);
  */
 void hal_log(const char* msg);
 
+/**
+ * @brief Configure a GPIO pin as an output
+ *
+ * This function configures the specified pin as a digital output.
+ * Call this once during initialization before using hal_gpio_write().
+ *
+ * @param pin Platform-specific pin number (e.g., Arduino pin 13)
+ *
+ * Platform Examples:
+ * - Simulation: Store pin configuration (no-op)
+ * - Arduino: pinMode(pin, OUTPUT)
+ * - ESP32: gpio_set_direction(pin, GPIO_MODE_OUTPUT)
+ */
+void hal_gpio_set_output(uint8_t pin);
+
+/**
+ * @brief Write a digital value to a GPIO pin
+ *
+ * This function sets the specified output pin to HIGH (1) or LOW (0).
+ * The pin must be configured as an output using hal_gpio_set_output() first.
+ *
+ * @param pin Platform-specific pin number
+ * @param value 1 for HIGH, 0 for LOW
+ *
+ * Platform Examples:
+ * - Simulation: printf() to show pin state change
+ * - Arduino: digitalWrite(pin, value ? HIGH : LOW)
+ * - ESP32: gpio_set_level(pin, value)
+ */
+void hal_gpio_write(uint8_t pin, uint8_t value);
+
 #ifdef __cplusplus
 }
 #endif

--- a/shared/core/node.c
+++ b/shared/core/node.c
@@ -19,6 +19,9 @@
 
 #include "hal.h"
 
+/** Status LED pin number (Arduino pin 13, ATmega328P PB5) */
+#define STATUS_LED_PIN 13
+
 /**
  * @brief Check if coordinator has already seen a JOIN request nonce (deduplication)
  *
@@ -97,6 +100,10 @@ void node_init(Node* n, Bus* bus, uint8_t instance_index) {
     // Set up basic node parameters
     n->bus = bus;
     n->instance_index = instance_index;
+    
+    // Initialize status LED pin
+    hal_gpio_set_output(STATUS_LED_PIN);
+    hal_gpio_write(STATUS_LED_PIN, 0);  // Start with LED off
 }
 
 /**
@@ -211,6 +218,10 @@ void node_begin(Node* n) {
 
             snprintf(msg, sizeof(msg), "Node[%u] → COORDINATOR (ID=1)", n->instance_index);
             hal_log(msg);
+            
+            // Turn on status LED to indicate startup sequence complete
+            hal_gpio_write(STATUS_LED_PIN, 1);
+            hal_log("Status LED: ON (Coordinator ready)");
         }
     }
 
@@ -321,6 +332,10 @@ void node_service(Node* n) {
                     char msg[64];
                     snprintf(msg, sizeof(msg), "ASSIGN received → MEMBER (ID=%u)", n->assigned_id);
                     hal_log(msg);
+                    
+                    // Turn on status LED to indicate startup sequence complete
+                    hal_gpio_write(STATUS_LED_PIN, 1);
+                    hal_log("Status LED: ON (Member ready)");
                 }
             }
         }

--- a/shared/platform/arduino/hal_arduino.c
+++ b/shared/platform/arduino/hal_arduino.c
@@ -28,3 +28,11 @@ void hal_log(const char* msg) {
     Serial.println(msg);
 }
 
+void hal_gpio_set_output(uint8_t pin) {
+    pinMode(pin, OUTPUT);
+}
+
+void hal_gpio_write(uint8_t pin, uint8_t value) {
+    digitalWrite(pin, value ? HIGH : LOW);
+}
+

--- a/shared/platform/sim/hal_sim.c
+++ b/shared/platform/sim/hal_sim.c
@@ -109,3 +109,30 @@ uint32_t hal_random32(void) {
 void hal_log(const char* msg) {
     printf("%s\n", msg);
 }
+
+/**
+ * @brief Configure GPIO pin as output (simulation stub)
+ *
+ * In simulation, this is a no-op but we log the configuration
+ * for debugging purposes. Real hardware would configure the
+ * pin direction in the GPIO controller.
+ *
+ * @param pin Pin number to configure
+ */
+void hal_gpio_set_output(uint8_t pin) {
+    printf("[GPIO] Pin %u configured as OUTPUT\n", pin);
+}
+
+/**
+ * @brief Write digital value to GPIO pin (simulation stub)
+ *
+ * In simulation, we log the pin state change to stdout.
+ * This allows verification that the status LED logic is
+ * working correctly during testing.
+ *
+ * @param pin Pin number to write
+ * @param value 1 for HIGH, 0 for LOW
+ */
+void hal_gpio_write(uint8_t pin, uint8_t value) {
+    printf("[GPIO] Pin %u → %s\n", pin, value ? "HIGH" : "LOW");
+}


### PR DESCRIPTION
Add GPIO control to HAL interface and implement status LED functionality that turns on when nodes complete their startup sequence and become operational (either as coordinator or member).

Changes:
- Add hal_gpio_set_output() and hal_gpio_write() to HAL interface
- Implement GPIO functions in Arduino HAL using pinMode()/digitalWrite()
- Add GPIO simulation stubs with logging for verification
- Initialize status LED (pin 13) in node_init() - starts OFF
- Turn LED ON when node becomes COORDINATOR after election
- Turn LED ON when node becomes MEMBER after ID assignment

Pin Selection:
- Uses pin 13 (Arduino built-in LED, ATmega328P PB5)
- Safe for all platforms: no conflict with ISP programming pins
- Compatible with Arduino Uno, R4 WiFi, and bare ATmega328P

Testing:
- All simulation tests pass (1, 3, 5 node scenarios)
- Arduino Uno and R4 WiFi compilation verified
- GPIO state changes logged in simulation for verification
- Maintains zero-ifdef architecture and clean HAL abstraction

The LED provides immediate visual feedback when boards are ready for operation, making it easy to verify system startup completion.